### PR TITLE
Bugfix/sometimes ui gets removed by page

### DIFF
--- a/tab-switcher.js
+++ b/tab-switcher.js
@@ -309,6 +309,12 @@
             populateTabs(matches);
         }
 
+        /**
+         * Appends the tab switcher HTML to the $container
+         *
+         * @param $container
+         * @returns {*}
+         */
         function appendTabSwitcherHtml($container) {
             if (!($container instanceof jQuery)) {
                 $container = $($container);
@@ -316,6 +322,22 @@
 
             $container.append(Config.MAIN_TEMPLATE);
             return $container;
+        }
+
+        /**
+         * Gets the tab switcher element and makes it visible. If it cannot find the element creates it.
+         */
+        function showTabSwitcher() {
+            var $tabSwitcher = $(Config.TAB_SWITCHER);
+
+            // Some pages remove the tab switcher HTML by chance
+            // so we check if the tab switcher was found and we re append if it is not found
+            if ($tabSwitcher.length === 0) {
+                appendTabSwitcherHtml(Config.TAB_SWITCHER_CONTAINER);
+                $tabSwitcher = $(Config.TAB_SWITCHER);
+            }
+
+            $tabSwitcher.show();
         }
 
         return {
@@ -380,19 +402,6 @@
                             }
                     }
                 });
-
-                function showTabSwitcher() {
-                    var $tabSwitcher = $(Config.TAB_SWITCHER);
-
-                    // Some pages remove the tab switcher HTML by chance
-                    // so we check if the tab switcher was found and we re append if it is not found
-                    if ($tabSwitcher.length === 0) {
-                        appendTabSwitcherHtml(Config.TAB_SWITCHER_CONTAINER);
-                        $tabSwitcher = $(Config.TAB_SWITCHER);
-                    }
-
-                    $tabSwitcher.show();
-                }
 
                 // Master key binding for which extension will be enabled
                 key(Config.MASTER_KEY, function () {

--- a/tab-switcher.js
+++ b/tab-switcher.js
@@ -309,16 +309,16 @@
             populateTabs(matches);
         }
 
+        function appendTabSwitcherHtml($container) {
+            if (!($container instanceof jQuery)) {
+                $container = $($container);
+            }
+
+            $container.append(Config.MAIN_TEMPLATE);
+            return $container;
+        }
+
         return {
-
-            appendTabSwitcherHtml: function ($container) {
-                if (!($container instanceof jQuery)) {
-                    $container = $($container);
-                }
-
-                $container.append(Config.MAIN_TEMPLATE);
-                return $container;
-            },
 
             /**
              * Loads the extension in specified container
@@ -326,7 +326,7 @@
              * @param $container
              */
             loadExtension: function ($container) {
-                this.appendTabSwitcherHtml($container);
+                appendTabSwitcherHtml($container);
                 this.bindUI();
             },
 
@@ -334,8 +334,6 @@
              * Binds the UI elements for the extension
              */
             bindUI: function () {
-                var self = this;
-
                 // mouse-down instead of click because click gets triggered after the blur event in which case tab
                 // switcher would already be hidden (@see blur event below) and click will not be performed
                 $(document).on('mousedown', Config.TAB_ITEM, function () {
@@ -383,14 +381,13 @@
                     }
                 });
 
-
                 function showTabSwitcher() {
                     var $tabSwitcher = $(Config.TAB_SWITCHER);
 
                     // Some pages remove the tab switcher HTML by chance
                     // so we check if the tab switcher was found and we re append if it is not found
                     if ($tabSwitcher.length === 0) {
-                        self.appendTabSwitcherHtml(Config.TAB_SWITCHER_CONTAINER);
+                        appendTabSwitcherHtml(Config.TAB_SWITCHER_CONTAINER);
                         $tabSwitcher = $(Config.TAB_SWITCHER);
                     }
 

--- a/tab-switcher.js
+++ b/tab-switcher.js
@@ -42,6 +42,7 @@
         TAB_LIST      : '.tab-switcher .tabs-list',
         TAB_ITEM      : '.tab-item',
         TAB_INPUT     : '.tab-switcher input[type="text"]',
+        TAB_SWITCHER_CONTAINER: 'body',
 
         // Shortcut for activation
         MASTER_KEY    : '⌘+⇧+k, ⌃+⇧+k',
@@ -310,18 +311,22 @@
 
         return {
 
+            appendTabSwitcherHtml: function ($container) {
+                if (!($container instanceof jQuery)) {
+                    $container = $($container);
+                }
+
+                $container.append(Config.MAIN_TEMPLATE);
+                return $container;
+            },
+
             /**
              * Loads the extension in specified container
              *
              * @param $container
              */
             loadExtension: function ($container) {
-                if (!($container instanceof jQuery)) {
-                    $container = $($container);
-                }
-
-                $container.append(Config.MAIN_TEMPLATE);
-
+                this.appendTabSwitcherHtml($container);
                 this.bindUI();
             },
 
@@ -329,6 +334,7 @@
              * Binds the UI elements for the extension
              */
             bindUI: function () {
+                var self = this;
 
                 // mouse-down instead of click because click gets triggered after the blur event in which case tab
                 // switcher would already be hidden (@see blur event below) and click will not be performed
@@ -377,9 +383,23 @@
                     }
                 });
 
+
+                function showTabSwitcher() {
+                    var $tabSwitcher = $(Config.TAB_SWITCHER);
+
+                    // Some pages remove the tab switcher HTML by chance
+                    // so we check if the tab switcher was found and we re append if it is not found
+                    if ($tabSwitcher.length === 0) {
+                        self.appendTabSwitcherHtml(Config.TAB_SWITCHER_CONTAINER);
+                        $tabSwitcher = $(Config.TAB_SWITCHER);
+                    }
+
+                    $tabSwitcher.show();
+                }
+
                 // Master key binding for which extension will be enabled
                 key(Config.MASTER_KEY, function () {
-                    $(Config.TAB_SWITCHER).show();
+                    showTabSwitcher();
                     $(Config.TAB_INPUT).focus();
 
                     BrowserTab.getAll(populateTabs);
@@ -390,7 +410,7 @@
 
     $(document).ready(function () {
         var tabSwitcher = new TabSwitcher();
-        tabSwitcher.loadExtension('body');
+        tabSwitcher.loadExtension(Config.TAB_SWITCHER_CONTAINER);
     });
 
 }());


### PR DESCRIPTION
I noticed that some pages accidentally remove the HTML of the TabSwitcher breaking its functionality. One example of this is when you are signed in in the [wunderlist web application](https://www.wunderlist.com).

In this branch I'm reattaching the TabSwitcher HTML if the element is not found when it is being made visible for use. This fixes the problem.