### PR TITLE
Stop leaking current URL in HTTP 'Referer' header

### DIFF
--- a/tab-switcher.js
+++ b/tab-switcher.js
@@ -21,7 +21,8 @@
         DEFAULT_FAVICON: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAQAAAC1+jfqAAAAMklEQVR4AWMgEkT9R4INWBUgKX0Q1YBXQYQCkhKEMDILogSnAhhEV4AGRqoCTEhkPAMAbO9DU+cdCDkAAAAASUVORK5CYII=',
 
         // Templates
-        MAIN_TEMPLATE :'<div class="tab-switcher" style="display: none;">' +
+        MAIN_TEMPLATE : '<meta name="referrer" content="origin" />' +
+        '<div class="tab-switcher" style="display: none;">' +
         '<input type="text">' +
         '<ul class="tabs-list">' +
         '</ul>' +


### PR DESCRIPTION
It would be best to prevent the leak with the following meta tag
which unfortunately breaks some sites which require HTTP Referers:
    `<meta name="referrer" content="no-referrer" />`
