### PR TITLE
Only load favicon over HTTPS

### DIFF
--- a/tab-switcher.js
+++ b/tab-switcher.js
@@ -302,7 +302,12 @@
             tabs.forEach(function(tab){
 
                 var tempTabTemplate = Config.TAB_TEMPLATE,
-                    faviconUrl = tab.favIconUrl || Config.DEFAULT_FAVICON;
+                    faviconUrl = Config.DEFAULT_FAVICON;
+
+                if (tab.favIconUrl && tab.favIconUrl.indexOf('https://') === 0) {
+                    // Only load actual favicon if loaded via HTTPS
+                    faviconUrl = tab.favIconUrl;
+                }
 
                 tempTabTemplate = tempTabTemplate.replace('{favicon}', faviconUrl);
                 tempTabTemplate = tempTabTemplate.replace('{default_favicon}', Config.DEFAULT_FAVICON);


### PR DESCRIPTION
This is to ensure no MITM can inject bogus images.